### PR TITLE
Updated SnakeYaml version to work on Android devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ allprojects {
   
   repositories {
     jcenter()
+    maven { url "http://oss.sonatype.org/content/groups/public/" }
   }
 }
 

--- a/mockwebserverplus/build.gradle
+++ b/mockwebserverplus/build.gradle
@@ -67,7 +67,7 @@ dependencies {
   compile('com.squareup.okhttp3:mockwebserver:3.7.0') {
     exclude group: "junit"
   }
-  compile('org.yaml:snakeyaml:1.14') {
+  compile('org.yaml:snakeyaml:1.19-SNAPSHOT:android') {
     transitive false
   }
 


### PR DESCRIPTION
The current version of Yaml (1.14) doesn't work on Android devices or emulators. The newer version supports Android. 
Unfortunately, it uses the SNAPSHOT version of the library... SAD! - which means I won't be able to use it offline on the subway... but at least it works. 
If there's a better way to do it, by all means, use that way.
The current 1.14 version causes this exception:

```
java.lang.NoClassDefFoundError: Failed resolution of: Ljava/beans/Introspector;
at org.yaml.snakeyaml.introspector.PropertyUtils.getPropertiesMap(PropertyUtils.java:63)

```
I'm going to try to figure out a way to share yaml and json between `test` and `androidTest` and update the README.